### PR TITLE
Dockerfile: download go deps in separate layer to improve caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ FROM golang:1.21.4 as binary
 
 WORKDIR /app
 
+COPY server/go.mod server/go.sum /app/server/
+RUN cd server && go mod download
+
 COPY server/. server/.
 COPY --from=frontend /app/dist/ server/webapp/
 


### PR DESCRIPTION
I just recently did this in my fork, and it saves me a few seconds, which is nice.